### PR TITLE
Universal afval data fetcher

### DIFF
--- a/run.py
+++ b/run.py
@@ -1,19 +1,9 @@
 from bs4 import BeautifulSoup
-import requests
-from datetime import datetime, timedelta
+from datetime import datetime, date
 import locale
-import icalendar
-
-def is_plastic(soup):
-    """Return ``True`` when the element contains plastic waste info."""
-    if soup.find("p", {"class": "plastic"}) is not None:
-        return True
-    return False
-
-def get_plastic(soup):
-    res = soup.find("p", {"class": "plastic"})
-    # Split the text into lines and remove empty parts/whitespace
-    return [line.strip() for line in res.text.split("\n") if line.strip()]
+from urllib.request import Request, urlopen
+from urllib.error import HTTPError
+import sys
 
 # Ensure month and weekday names are parsed/created in Dutch.  Not all
 # systems provide the ``nl_NL`` locale, so fall back gracefully when it is
@@ -26,51 +16,141 @@ except locale.Error:
     except locale.Error:
         locale.setlocale(locale.LC_TIME, '')
 
-url = "http://mijnafvalwijzer.nl"
-postcode = "3603AN"
-huisnummer = 54
-jaar = 2025
+BASE_URL = "https://mijnafvalwijzer.nl"
 
-res = requests.get(url=f"{url}/nl/{postcode}/{huisnummer}/#jaar-{jaar}")
-soup = BeautifulSoup(res.content, "html.parser")
 
-dates = soup.find_all("a", {"class":"wasteInfoIcon textDecorationNone"})
-ls = []
-for date in dates:
-    if is_plastic(date):
-        datum, afval = get_plastic(date)
-    else:
-        datum = date.find("span", {"class": "span-line-break"}).text.strip()
-        afval = date.find("span", {"class": "afvaldescr"}).text.strip()
 
-    dt = datetime.strptime(datum.strip(), "%A %d %B %Y")
-    ls.append((dt.date(), afval))
 
-# Create calendar
-cal = icalendar.Calendar()
-cal.add('prodid', f'afvalkalender {postcode} {huisnummer}')
-cal.add('version', '2.0')
-cal.add("X-WR-CALNAME", f"Afvalkalender {jaar}")
+class WasteFetcher:
+    MONTHS = {
+        "januari": 1,
+        "februari": 2,
+        "maart": 3,
+        "april": 4,
+        "mei": 5,
+        "juni": 6,
+        "juli": 7,
+        "augustus": 8,
+        "september": 9,
+        "oktober": 10,
+        "november": 11,
+        "december": 12,
+    }
 
-for n, (datum, afval) in enumerate(ls):
-    if datum.year != jaar:
-        continue
-    event = icalendar.Event()
-    event.add("dtstamp", datetime.now())
-    event.add("uid", n)
-    event.add('summary', afval)
-    event.add('dtstart', datum)
-    alarm_6h_before = icalendar.Alarm()
-    alarm_6h_before.add('action', 'DISPLAY')
-    alarm_6h_before.add('trigger', timedelta(hours=-6))
-    alarm_6h_before.add('description', '')
-    alarm_6h_after = icalendar.Alarm()
-    alarm_6h_after.add('action', 'DISPLAY')
-    alarm_6h_after.add('trigger', timedelta(hours=6))
-    alarm_6h_after.add('description', '')
-    event.add_component(alarm_6h_before)
-    event.add_component(alarm_6h_after)
-    cal.add_component(event)
+    def __init__(self, postcode: str, huisnummer: int):
+        self.postcode = postcode
+        self.huisnummer = huisnummer
 
-with open('afval.ics', 'wb') as f:
-    f.write(cal.to_ical())
+    @staticmethod
+    def parse_dutch_date(text: str, year: int) -> date:
+        """Parse a date string like 'maandag 01 januari' for ``year``."""
+        parts = text.lower().split()
+        if len(parts) < 3:
+            raise ValueError("Unrecognized date format")
+        day = int(parts[1])
+        month = WasteFetcher.MONTHS.get(parts[2])
+        if not month:
+            raise ValueError("Unknown month")
+        return date(year, month, day)
+
+    @staticmethod
+    def categorize(name: str) -> str:
+        """Return one of the known waste categories for ``name``."""
+        text = name.lower()
+        if (
+            "pmd" in text
+            or "plastic" in text
+            or "metaal" in text
+            or "drankkarton" in text
+        ):
+            return "PMD"
+        if "papier" in text or "karton" in text:
+            return "Papier en karton"
+        if (
+            "gft" in text
+            or "groente" in text
+            or "fruit" in text
+            or "tuin" in text
+        ):
+            return "GFT"
+        if "rest" in text:
+            return "Restafval"
+        return name.strip()
+
+    def _url(self, year: int) -> str:
+        return f"{BASE_URL}/nl/{self.postcode}/{self.huisnummer}/#jaar-{year}"
+
+    def fetch(self, year: int) -> list[tuple[date, str]]:
+        req = Request(self._url(year), headers={"User-Agent": "Mozilla/5.0"})
+        try:
+            with urlopen(req) as res:
+                html = res.read()
+        except HTTPError as exc:
+            print(f"Failed to fetch {self.postcode}-{self.huisnummer}: {exc}")
+            return []
+        soup = BeautifulSoup(html, "html.parser")
+        section = soup.find(id=f"jaar-{year}")
+        if not section:
+            return []
+        results = []
+        for item in section.select("a.wasteInfoIcon"):
+            datum_tag = item.find("span", class_="span-line-break")
+            afval_tag = item.find("span", class_="afvaldescr")
+            if datum_tag is None or afval_tag is None:
+                continue
+            datum = datum_tag.get_text(strip=True)
+            afval = afval_tag.get_text(strip=True)
+            try:
+                dt = self.parse_dutch_date(datum, year)
+            except Exception:
+                continue
+            results.append((dt, self.categorize(afval)))
+        return results
+
+
+def export_ical(filename: str, items: list[tuple[date, str]], postcode: str, huisnummer: int):
+    """Write the waste data to an iCalendar file."""
+    lines = [
+        "BEGIN:VCALENDAR",
+        "VERSION:2.0",
+        f"PRODID:-//afvalkalender//{postcode}-{huisnummer}//EN",
+        f"X-WR-CALNAME:Afval {postcode} {huisnummer}",
+    ]
+    stamp = datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+    for dt, cat in items:
+        uid = f"{postcode}-{huisnummer}-{dt.isoformat()}"
+        lines.extend([
+            "BEGIN:VEVENT",
+            f"UID:{uid}",
+            f"DTSTAMP:{stamp}",
+            f"DTSTART;VALUE=DATE:{dt.strftime('%Y%m%d')}",
+            f"SUMMARY:{cat}",
+            "END:VEVENT",
+        ])
+    lines.append("END:VCALENDAR")
+    with open(filename, "w") as fh:
+        fh.write("\n".join(lines))
+
+
+def main(argv: list[str] | None = None):
+    if argv is None:
+        argv = sys.argv[1:]
+    if len(argv) != 2:
+        print("Usage: python run.py <postcode> <huisnummer>")
+        return
+    postcode, huisnummer_str = argv
+    try:
+        huisnummer = int(huisnummer_str)
+    except ValueError:
+        print("Huisnummer must be a number")
+        return
+    year = datetime.now().year
+    fetcher = WasteFetcher(postcode, huisnummer)
+    items = fetcher.fetch(year)
+    for dt, cat in items:
+        print(dt, cat)
+    export_ical("afval.ics", items, postcode, huisnummer)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- remove unused WasteManager and fetch a single postcode/huisnummer pair from CLI args
- generate simple iCalendar output with `export_ical`
- write ICS events for each waste pickup date

## Testing
- `python3 run.py 3997MH 63`
- `python3 run.py 3603AN 54`


------
https://chatgpt.com/codex/tasks/task_e_686f937e096c832180c09b697ca215fc