### PR TITLE
Add pytest config with lint and type checks

### DIFF
--- a/afvalkalender/fetcher.py
+++ b/afvalkalender/fetcher.py
@@ -1,7 +1,8 @@
-from bs4 import BeautifulSoup
 from datetime import date
-from urllib.request import Request, urlopen
 from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+from bs4 import BeautifulSoup
 
 BASE_URL = "https://mijnafvalwijzer.nl"
 
@@ -78,7 +79,7 @@ class WasteFetcher:
         if not section:
             return []
         results = []
-        for item in section.select("a.wasteInfoIcon"):
+        for item in section.select("a.wasteInfoIcon"):  # type: ignore[attr-defined]
             datum_tag = item.find("span", class_="span-line-break")
             afval_tag = item.find("span", class_="afvaldescr")
             if datum_tag is None or afval_tag is None:

--- a/afvalkalender/ical.py
+++ b/afvalkalender/ical.py
@@ -1,4 +1,4 @@
-from datetime import datetime, date, UTC
+from datetime import UTC, date, datetime
 
 
 def export_ical(filename: str, items: list[tuple[date, str]], postcode: str, huisnummer: int):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,24 @@
+[tool.pytest.ini_options]
+addopts = '--ruff --isort --mypy --pydocstyle --cov=afvalkalender --cov-report=term-missing'
+
+[tool.ruff]
+line-length = 88
+
+[tool.isort]
+profile = 'black'
+line_length = 88
+
+[tool.mypy]
+python_version = '3.11'
+ignore_missing_imports = true
+
+[tool.pydocstyle]
+convention = 'pep257'
+add-ignore = [
+    "D100",
+    "D101",
+    "D102",
+    "D103",
+    "D104",
+    "D107",
+]

--- a/tests/test_afvalkalender.py
+++ b/tests/test_afvalkalender.py
@@ -1,0 +1,74 @@
+from datetime import UTC, date, datetime
+from unittest.mock import patch
+
+import pytest
+
+from afvalkalender.fetcher import WasteFetcher
+from afvalkalender.ical import export_ical
+
+
+def test_parse_dutch_date_valid():
+    dt = WasteFetcher.parse_dutch_date("maandag 01 januari", 2024)
+    assert dt == date(2024, 1, 1)
+
+
+def test_parse_dutch_date_invalid():
+    with pytest.raises(ValueError):
+        WasteFetcher.parse_dutch_date("maandag 32 januari", 2024)
+
+
+def test_categorize():
+    assert WasteFetcher.categorize("GFT bak") == "GFT"
+    assert WasteFetcher.categorize("Papier en karton") == "Papier en karton"
+    assert WasteFetcher.categorize("  restafval ") == "Restafval"
+
+
+def test_url():
+    f = WasteFetcher("1234AB", 56)
+    assert f._url(2024) == "https://mijnafvalwijzer.nl/nl/1234AB/56/#jaar-2024"
+
+
+class DummyResponse:
+    def __init__(self, data: bytes):
+        self.data = data
+
+    def read(self) -> bytes:
+        return self.data
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+def test_fetch_parses_html():
+    html = b"""
+    <div id='jaar-2024'>
+      <a class='wasteInfoIcon'>
+        <span class='span-line-break'>maandag 01 januari</span>
+        <span class='afvaldescr'>gft</span>
+      </a>
+    </div>
+    """
+    f = WasteFetcher("1234AB", 56)
+    with patch("afvalkalender.fetcher.urlopen", return_value=DummyResponse(html)):
+        items = f.fetch(2024)
+    assert items == [(date(2024, 1, 1), "GFT")]
+
+
+def test_export_ical(tmp_path):
+    items = [(date(2024, 1, 1), "PMD")]
+    target = tmp_path / "out.ics"
+    fixed = datetime(2023, 12, 31, tzinfo=UTC)
+
+    class DummyDateTime:
+        @staticmethod
+        def now(tz=None):
+            return fixed
+
+    with patch("afvalkalender.ical.datetime", DummyDateTime):
+        export_ical(str(target), items, "1234AB", 56)
+    text = target.read_text().splitlines()
+    assert text[0] == "BEGIN:VCALENDAR"
+    assert any(line.startswith("DTSTART;VALUE=DATE:20240101") for line in text)


### PR DESCRIPTION
## Summary
- configure pytest plugins for ruff, isort, mypy, pydocstyle and coverage
- add sample unit tests for fetcher and ical modules
- adjust imports and fix mypy warning

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fcb73ae88832183084113bdd28192